### PR TITLE
Add support for multiple audio samples

### DIFF
--- a/assets/js/lib/audio.js
+++ b/assets/js/lib/audio.js
@@ -183,10 +183,14 @@ export function playBeep(inst, when) {
   }
 }
 
-export function triggerTrack(id, when, beepInst, sampleBuffer) {
+export function triggerTrack(id, when, beepInst, samples) {
   if (id === "kick") return playKick(when);
   if (id === "snare") return playSnare(when);
   if (id === "hat") return playHat(when);
-  if (id === "sample") return playSample(sampleBuffer, when);
+  if (id === "sample" || id.startsWith("sample")) {
+    const buf = samples && samples[id];
+    if (buf) return playSample(buf, when);
+    return;
+  }
   if (beepInst && beepInst[id]) return playBeep(beepInst[id], when);
 }

--- a/assets/js/lib/tracks.js
+++ b/assets/js/lib/tracks.js
@@ -4,13 +4,19 @@ export function beepLabel(id) {
   return Number.isFinite(n) ? `Beep ${n}` : "Beep";
 }
 
-export function rebuildTracks(beepIds) {
+export function sampleLabel(id) {
+  if (id === "sample") return "Sample";
+  const n = parseInt(id.replace("sample", ""), 10);
+  return Number.isFinite(n) ? `Sample ${n}` : "Sample";
+}
+
+export function rebuildTracks(beepIds, sampleIds = ["sample"]) {
   return [
     { id: "kick", name: "Kick" },
     { id: "snare", name: "Snare" },
     { id: "hat", name: "Hat" },
     ...beepIds.map(id => ({ id, name: beepLabel(id) })),
-    { id: "sample", name: "Sample" },
+    ...(sampleIds && sampleIds.length ? sampleIds.map(id => ({ id, name: sampleLabel(id) })) : [{ id: "sample", name: "Sample" }]),
   ];
 }
 

--- a/index.html
+++ b/index.html
@@ -36,10 +36,10 @@
 
       <div class="sample-upload">
         <label class="file">
-          <span>Upload sample</span>
-          <input id="sampleFile" type="file" accept="audio/*">
+          <span>Upload sample(s)</span>
+          <input id="sampleFile" type="file" accept="audio/*" multiple>
         </label>
-        <span id="sampleStatus" class="muted">No sample</span>
+        <span id="sampleStatus" class="muted">No samples</span>
       </div>
     </section>
 


### PR DESCRIPTION
This update enhances the audio playback functionality by allowing users to upload and trigger multiple audio samples instead of just one. The changes include:

- **Modification of the `triggerTrack` function:** It now accepts an object containing multiple samples, enabling the playback of samples based on their IDs.
- **New `sampleLabel` function:** This generates labels for the sample tracks dynamically.
- **Updated `rebuildTracks` function:** This builds the track list, incorporating the new sample IDs.
- **Updated sample upload functionality:** Users can now upload multiple audio files at once, which are processed and stored for playback, replacing the previous single sample upload logic.
- **User interface changes:** The file input in `index.html` has been modified to allow multiple files to be selected for upload.

These improvements collectively enhance the application's capability to manage and play multiple audio samples, providing a richer user experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [music-maker/jlundk68w8ft](https://cosine.wtf/cosine-stg/music-maker/task/jlundk68w8ft)
Author: Curtis Huang
