### PR TITLE
Add sound recording feature to allow users to record samples

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,10 +35,13 @@
       </div>
 
       <div class="sample-upload">
-        <label class="file">
-          <span>Upload sample</span>
-          <input id="sampleFile" type="file" accept="audio/*">
-        </label>
+        <div class="sample-actions" style="display:inline-flex; align-items:center; gap:0.6rem;">
+          <label class="file">
+            <span>Upload sample</span>
+            <input id="sampleFile" type="file" accept="audio/*">
+          </label>
+          <button id="recordBtn">Record sample</button>
+        </div>
         <span id="sampleStatus" class="muted">No sample</span>
       </div>
     </section>


### PR DESCRIPTION
This pull request introduces a new feature that allows users to record audio directly from their microphone and use it as a sample in the music toy application. 

Key changes include:
- Added a 'Record sample' button in `index.html` for users to initiate audio recording.
- Implemented the audio recording functionality in `main.js`, utilizing the MediaRecorder API to capture audio, store it as a buffer, and display the recording status.
- Users can now record sound, which will be processed and can be used as a sample, enhancing the functionality of the application and providing a more interactive user experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [music-maker/17rip0j9f19u](https://cosine.wtf/cosine-stg/music-maker/task/17rip0j9f19u)
Author: Curtis Huang
